### PR TITLE
Use standalone transforms for main menu animation

### DIFF
--- a/game/screens.rpy
+++ b/game/screens.rpy
@@ -167,11 +167,13 @@ screen main_menu():
 
     if ball_active:
         add "gui/screens/main_menu/background2.png"
-        add "gui/screens/main_menu/crystal_ball.png" xalign 0.5 ypos 230 #at dissolve
-
-    if ball_active == False:
+    else:
         add "gui/screens/main_menu/background.png"
-        add "floating_crystal_ball"
+
+    showif ball_active:
+        add "gui/screens/main_menu/crystal_ball.png" at crystal_ball_stop
+    else:
+        add "gui/screens/main_menu/crystal_ball.png" at crystal_ball_float
         add "ball_shadow_animation"
 
     if gui.show_name:

--- a/game/theme_stuff.rpy
+++ b/game/theme_stuff.rpy
@@ -1,21 +1,41 @@
 init offset = -1
 
+transform crystal_ball_float:
+    subpixel True
+    xalign 0.5
+    ypos 225
+    on appear, show:
+        linear 1.0 ypos 210
+        block:
+            linear 2.0 ypos 240
+            linear 2.0 ypos 210
+            repeat
+    on hide:
+        easein_expo 0.5 ypos 225
+
+transform crystal_ball_stop:
+    subpixel True
+    xalign 0.5
+    ypos 225
+    alpha 0.0
+    on show:
+        time 0.5
+        alpha 1.0
+    on hide:
+        alpha 0.0
+
 image ball_shadow_animation:
     subpixel True
     xalign 0.5
     ypos 950
+    zoom 1.1
     "gui/screens/main_menu/ball_shadow.png"
-    linear 2.0 zoom 1.20
-    linear 2.0 zoom 1.0
-    repeat
-image floating_crystal_ball:
-    subpixel True
-    "gui/screens/main_menu/crystal_ball.png"
-    xalign 0.5
-    ypos 200
-    linear 2.0 ypos 240
-    linear 2.0 ypos 200
-    repeat
+    on appear, show:
+        linear 1.0 zoom 1.0
+        block:
+            linear 2.0 zoom 1.2
+            linear 2.0 zoom 1.0
+            repeat
 image star:
     subpixel True
     choice:


### PR DESCRIPTION
This removes the jumping of the main menu graphics when the menu gets selected. I think this is the simplest way to do it without storing positional information outside of a transform.

Main things to note:
 - the changes are driven by events within the transforms and switching with `showif`; it didn't work to keep the image and transform defined together, so the transforms are now separate
- because there is no state information the animation always resumes in the same direction
- the animation always starts from the center position (including the shadow animation)
- perhaps there is a better warper to use than `easein_expo`, but this seemed the best from the ones I tried
- I've not tested any screen variants (mobile etc.)

Thanks!