### PR TITLE
Fix crystal ball on choice screen

### DIFF
--- a/game/screens.rpy
+++ b/game/screens.rpy
@@ -59,7 +59,8 @@ screen choice(items):
     default i = 0
     style_prefix "choice"
     add "gui/screens/overlay.png"
-    add "floating_crystal_ball"
+    showif True:
+        add "gui/screens/main_menu/crystal_ball.png" at crystal_ball_float
     add "twinkle" pos(470,200)
 
 


### PR DESCRIPTION
Apologies, I hadn't realised that the same transform was also used in the choice screen, so there was a missing image error. This just uses the source image and the new transform, with showif needed to send the event that starts the movement.